### PR TITLE
fix: css-loader config for parsing urls properly

### DIFF
--- a/src/server/config/webpack.js
+++ b/src/server/config/webpack.js
@@ -40,6 +40,12 @@ export default (server) => {
 	const { dev, filename, staticDir, cssDir, babelTranspileModules, sourceStylesDir, onWebpackProgress } =
 		server.getConfig();
 	const { plugins, ...config } = server.getConfig().webpack;
+	const cssLoader = {
+		loader: 'css-loader',
+		options: {
+			url: false,
+		},
+	}
 	const postCSSLoader = {
 		loader: 'postcss-loader',
 		options: {
@@ -121,7 +127,7 @@ export default (server) => {
 										},
 									},
 								},
-								'css-loader',
+								cssLoader,
 								postCSSLoader,
 						  ]
 						: prodStyleLoader,
@@ -138,7 +144,7 @@ export default (server) => {
 										},
 									},
 								},
-								'css-loader',
+								cssLoader,
 								postCSSLoader,
 								'sass-loader',
 						  ]


### PR DESCRIPTION
i dont know what upgrade of what caused this (webpack, css-loader, sass-loader?) but this is mentioned a lot of times that people needed to turn this off, so the urls are parsed properly in css/sass files, e.g. url: `/images/...` as we discussed.